### PR TITLE
fix: github workflow invalid ref value

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -23,7 +23,7 @@ jobs:
   commitizen:
     needs: ["molecule"]
     name: "Bump version and create changelog with commitizen"
-    if: "!startsWith(github.event.head_commit.message, 'bump:') && github.event_name == 'push' && github.ref == 'main'"
+    if: "!startsWith(github.event.head_commit.message, 'bump:') && github.event_name == 'push' && github.ref == 'refs/heads/main'"
     runs-on: "ubuntu-latest"
     steps:
       - name: Check out
@@ -43,7 +43,7 @@ jobs:
     name: "Deploy role to Ansible Galaxy"
     needs: ["molecule", "commitizen"]
     runs-on: "ubuntu-latest"
-    if: "github.event_name == 'push' && github.ref == 'main'"
+    if: "github.event_name == 'push' && github.ref == 'refs/heads/main'"
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
The refs for the context variable `github.ref` must be in the format `refs/heads/<branch>`. The specified value of `main` does always evaluate to false and the corresponding steps are not triggered.

Further: a push with the `secrets.GITHUB_TOKEN` does not trigger github actions by design. Therefore the release will only be triggered in the pipeline which also triggers commitizen.