### PR TITLE
Fix galaxy deploy

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -51,3 +51,4 @@ jobs:
         uses: robertdebock/galaxy-action@1.2.0
         with:
           galaxy_api_key: ${{ secrets.GALAXY_TOKEN }}
+          git_branch: main


### PR DESCRIPTION
Even though being reported as successful, the deployment to galaxy fails because the default branch `master` can not be found. This PR explicitly sets the branch name to `main` for the deployment task.